### PR TITLE
Collision example

### DIFF
--- a/source/Fireball.hx
+++ b/source/Fireball.hx
@@ -1,0 +1,21 @@
+package;
+
+import flixel.FlxSprite;
+import flixel.math.FlxPoint;
+import flixel.system.FlxAssets.FlxGraphicAsset;
+import flixel.util.FlxColor;
+
+/**
+ * Very simple class, used to demonstrate how FlxG.overlap can be used.
+ * @author Samuel Bumgardner
+ */
+class Fireball extends FlxSprite
+{
+	public function new(?X:Float=0, ?Y:Float=0, ?initialVelocityX:Float = 0, ?initialVelocityY:Float = 0) 
+	{
+		super(X, Y);
+		this.makeGraphic(15, 15, FlxColor.RED);
+		
+		this.velocity.set(initialVelocityX, initialVelocityY);
+	}
+}

--- a/source/Ground.hx
+++ b/source/Ground.hx
@@ -1,0 +1,20 @@
+package;
+
+import flixel.FlxSprite;
+import flixel.system.FlxAssets.FlxGraphicAsset;
+import flixel.util.FlxColor;
+
+/**
+ * ...
+ * @author Sam
+ */
+class Ground extends FlxSprite 
+{
+
+	public function new(?X:Float=0, ?Y:Float=0, ?SimpleGraphic:FlxGraphicAsset) 
+	{
+		super(X, Y, SimpleGraphic);
+		makeGraphic(32, 32, FlxColor.GRAY);
+	}
+	
+}

--- a/source/Ground.hx
+++ b/source/Ground.hx
@@ -5,7 +5,10 @@ import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.util.FlxColor;
 
 /**
- * ...
+ * Simple class to represent immovable terrain (in this case, the ground).
+ * 
+ * Using FlxSprite like this isn't actually very performant, it's better to
+ *  use some sort of tilemap to represent static terrain.
  * @author Sam
  */
 class Ground extends FlxSprite 
@@ -13,8 +16,14 @@ class Ground extends FlxSprite
 
 	public function new(?X:Float=0, ?Y:Float=0, ?SimpleGraphic:FlxGraphicAsset) 
 	{
+		// Basic setup, should be familiar now.
 		super(X, Y, SimpleGraphic);
-		makeGraphic(32, 32, FlxColor.GRAY);
+		this.makeGraphic(32, 32, FlxColor.GRAY);
+		
+		// immovable is a property of FlxSprite used by Haxeflixel's built-in
+		//  collision-resolving system. Setting it to true means it can't be
+		//  pushed around by other objects.
+		this.set_immovable(true);
 	}
 	
 }

--- a/source/Hero.hx
+++ b/source/Hero.hx
@@ -6,7 +6,7 @@ import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.util.FlxColor;
 
 /**
- * ...
+ * Our player-controlled hero class. 
  * @author Sam
  */
 class Hero extends FlxSprite 
@@ -14,17 +14,58 @@ class Hero extends FlxSprite
 
 	public function new(?X:Float=0, ?Y:Float=0, ?SimpleGraphic:FlxGraphicAsset) 
 	{
+		// Call parent constructor to do basic FlxSprite setup
 		super(X, Y, SimpleGraphic);
 		
-		this.makeGraphic(25, 25);
+		// Create basic rectangle graphic
+		this.makeGraphic(25, 25, FlxColor.ORANGE);
 		
-		this.velocity.set(FlxG.random.int(-20, 20), FlxG.random.int(-20, 20));
+		// Set acceleration and max velocity to represent gravity.
+		this.acceleration.y = 50;
+		this.maxVelocity.y = 200;
+		
+		// Set max velocity for x to limit speed of character
+		this.maxVelocity.x = 200;
 	}
 	
 	override public function update(elapsed:Float):Void
 	{
-		this.color = 0xffffff & (((Std.int(this.y) % 255) << 16 ) + ((Std.int(this.x) % 255) << 8) + ((Std.int(this.x) + Std.int(this.y)) % 255));
-				
+		//////////////////////////
+		// Basic input handling //
+		//////////////////////////
+		
+		// FlxG.keys.pressed values are booleans.
+		//  They indicate what keys are currently held down.
+		var leftPressed:Bool = FlxG.keys.pressed.LEFT;
+		var rightPressed:Bool = FlxG.keys.pressed.RIGHT;
+		
+		// FlxG.keys.justPressed values are reset each update().
+		//  This makes it good for inputs that need to be pressed, not held.
+		var spaceJustPressed:Bool = FlxG.keys.justPressed.SPACE;
+		
+		// Here are some *very* basic examples of how to respond to input.
+		//  You can do a lot more here to make the game feel much better.
+		if (leftPressed) { // Move left
+			this.acceleration.x = -50;
+		} 
+		else if (rightPressed) { // Move right
+			this.acceleration.x = 50;
+		}
+		else { // stop moving
+			this.acceleration.x = 0;
+			this.velocity.x = 0;
+		}
+		
+		if (spaceJustPressed) { // Jump. Note: no restrictions that prevent infinite jumping.
+			this.velocity.y = -100;
+		}
+		
+		
+		/////////////////////////
+		// Normal update stuff //
+		/////////////////////////
+		
+		// Call parent update, which will apply all physics, animations, etc.
 		super.update(elapsed);
 	}
 	

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1,5 +1,6 @@
 package;
 
+import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.FlxState;
 import flixel.group.FlxGroup;
@@ -7,6 +8,17 @@ import flixel.text.FlxText;
 
 class PlayState extends FlxState
 {
+	// I added some constant variables to the class definition.
+	// Rather than use random numbers in create(), we can reference
+	//  these variables that have some meaning attached to their names. 
+	private var TILE_SIZE(default, never):Int = 32;
+	
+	private var GROUND_POSITION_X(default, never):Int = 100;
+	private var GROUND_POSITION_Y(default, never):Int = 300;
+	
+	private var HERO_START_X(default, never):Int = 150;
+	private var HERO_START_Y(default, never):Int = 150;
+	
 	public var groundGrp:FlxGroup;
 	public var hero:Hero;
 	
@@ -16,17 +28,25 @@ class PlayState extends FlxState
 		
 		groundGrp = new FlxGroup();
 		for (i in 0...10) {
-			groundGrp.add(new Ground(100 + 32 * i, 100));
+			groundGrp.add(new Ground(GROUND_POSITION_X + TILE_SIZE * i, GROUND_POSITION_Y));
 		}
 		add(groundGrp);
 		
-		hero = new Hero(150, 50);
-		add(spr);
+		hero = new Hero(HERO_START_X, HERO_START_Y);
+		add(hero);
 		
 	}
 
 	override public function update(elapsed:Float):Void
 	{
+		// Let everything update (which lets them move into each other)
 		super.update(elapsed);
+		
+		/////////////////////
+		// Collision logic //
+		/////////////////////
+		
+		// FlxG's collide checks for overlap, then separates overlapping objects.
+		FlxG.collide(hero, groundGrp);
 	}
 }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -19,8 +19,15 @@ class PlayState extends FlxState
 	private var HERO_START_X(default, never):Int = 150;
 	private var HERO_START_Y(default, never):Int = 150;
 	
+	private var FIREBALL_START_X(default, never):Int = 400;
+	private var FIREBALL_START_Y(default, never):Int = 270;
+	private var FIREBALL_START_VELOCITY_X(default, never):Int = -50;
+	
+	// It's a good idea to keep these as instance variables so we can reference
+	//  them inisde our update function.
 	public var groundGrp:FlxGroup;
 	public var hero:Hero;
+	public var fireball:Fireball;
 	
 	override public function create():Void
 	{
@@ -35,6 +42,8 @@ class PlayState extends FlxState
 		hero = new Hero(HERO_START_X, HERO_START_Y);
 		add(hero);
 		
+		fireball = new Fireball(FIREBALL_START_X, FIREBALL_START_Y, FIREBALL_START_VELOCITY_X);
+		add(fireball);
 	}
 
 	override public function update(elapsed:Float):Void
@@ -48,5 +57,34 @@ class PlayState extends FlxState
 		
 		// FlxG's collide checks for overlap, then separates overlapping objects.
 		FlxG.collide(hero, groundGrp);
+		
+		// Here we use FlxG.overlap to do custom logic when overlap occurs.
+		FlxG.overlap(hero, fireball, collideHeroAndFireball);
+		
+		//////////////////////
+		// Other game logic //
+		//////////////////////
+		
+		// For our convenience, let's reset the hero whenever killed or taken off-screen.
+		if (!hero.alive || !hero.isOnScreen()) {
+			hero.reset(HERO_START_X, HERO_START_Y);
+		}
+		
+		// For our convenience, let's reset the fireball whenever killed or taken off-screen.
+		if (!fireball.alive || !fireball.isOnScreen()) {
+			fireball.reset(FIREBALL_START_X, FIREBALL_START_Y);
+			fireball.velocity.x = FIREBALL_START_VELOCITY_X;
+		}
+	}
+	
+	/**
+	 * Basic overlap resolution function - when a hero and fireball overlap, both are killed.
+	 * @param	hero
+	 * @param	fireball
+	 */
+	private function collideHeroAndFireball(hero:Hero, fireball:Fireball):Void
+	{
+		hero.kill();
+		fireball.kill();
 	}
 }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -8,6 +8,7 @@ import flixel.text.FlxText;
 class PlayState extends FlxState
 {
 	public var groundGrp:FlxGroup;
+	public var hero:Hero;
 	
 	override public function create():Void
 	{
@@ -19,14 +20,9 @@ class PlayState extends FlxState
 		}
 		add(groundGrp);
 		
-		var text = new FlxText(0, 0, 0, "hello world", 64);
-		text.screenCenter();
-		add(text);
+		hero = new Hero(150, 50);
+		add(spr);
 		
-		for (i in 0...15) {
-			var spr = new Hero(200, 200);
-			add(spr);
-		}
 	}
 
 	override public function update(elapsed:Float):Void

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1,13 +1,23 @@
 package;
 
 import flixel.FlxState;
+import flixel.group.FlxGroup;
 import flixel.text.FlxText;
 
 class PlayState extends FlxState
 {
+	public var groundGrp:FlxGroup;
+	
 	override public function create():Void
 	{
 		super.create();
+		
+		groundGrp = new FlxGroup();
+		for (i in 0...10) {
+			groundGrp.add(new Ground(100 + 32 * i, 100));
+		}
+		add(groundGrp);
+		
 		var text = new FlxText(0, 0, 0, "hello world", 64);
 		text.screenCenter();
 		add(text);


### PR DESCRIPTION
There are quite a few changes in this PR, all of which are aimed at demonstrating how collision is handled in HaxeFlixel:

 * The `Hero` class now reacts to player input and operates under some basic physics rules.
     * While not strictly necessary, this does make testing more pleasant and maybe gives some ideas about how acceleration, velocity, collision, and overlap can combine to make a traditional platformer-type game.
 * Added `Ground` class.
     * Very simple, used to demonstrate use of `FlxG.collide` in `PlayState`
 * Added `Fireball` class.
     * Also very simple, used to demonstrate use of `FlxG.overlap` in `PlayState`
 * The `PlayState` class was altered in a number of ways:
     * Now only creates one instance of the `Hero` object
     * Creates a `Ground` and `Fireball` objects for the `Hero` to interact with.
     * Added logic inside of `update` to check for and react to overlap between both `Hero` / `Ground` and `Hero` / `Fireball`
     * Added a bit of extra logic to make testing more convenient - `Hero` and `Fireball` are both reset if killed or if sent off-screen.

Please review this code and familiarize yourself with it. If you have any questions about what a section of code is doing (or why I wrote in a particular way) go ahead and post questions onto this pull request.